### PR TITLE
Grid Mixins

### DIFF
--- a/_base.scss
+++ b/_base.scss
@@ -4,3 +4,4 @@
 @import "base/box-sizing";
 @import "base/images";
 @import "base/flexbox";
+@import "base/grid";

--- a/base/_grid.scss
+++ b/base/_grid.scss
@@ -1,0 +1,40 @@
+// Grid
+// Example use: @include grid;
+@mixin grid {
+    display: -ms-grid;
+    display: grid;
+}
+
+// Inline Grid
+// Example use: @include inline-grid;
+@mixin inline-grid {
+    display: -ms-inline-grid;
+    display: inline-grid;
+}
+
+// Grid Template Rows
+// Example use: @include grid-template-rows(auto, minmax(50px, 1fr), 100px)
+// Note: You must use an Autoprefixer to use repeat() with grid-template-columns in IE11
+@mixin grid-template-rows($values) {
+    -ms-grid-rows: $values;
+    grid-template-rows: $values;
+}
+
+// Grid Template Columns
+// Example use: @include grid-template-columns(1fr, 1fr, 100px)
+// Note: You must use an Autoprefixer to use repeat() with grid-template-columns in IE11
+@mixin grid-template-columns($values) {
+    -ms-grid-columns: $values;
+    grid-template-columns: $values;
+}
+
+// To position individual grid cells
+// Example use: @include grid-cell(2,2,1,1)
+@mixin grid-cell($col-start, $col-end, $row-start, $row-end) {
+    -ms-grid-column: $col-start;
+    -ms-grid-column-span: $col-end - $col-start;
+    -ms-grid-row: $row-start;
+    -ms-grid-row-span: $row-end - $row-start;
+    grid-column: #{$col-start}/#{$col-end};
+    grid-row: #{$row-start}/#{$row-end};
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "oleg-starter-pack",
-    "version": "2.0.1",
+    "version": "2.0.2",
     "description": "Some handy base Sass and utility classes for use in projects.",
     "main": "index.js",
     "repository": "git@github.com:AgePartnership/oleg-starter-pack.git",


### PR DESCRIPTION
Made for Express Microsite, ticket ref: https://webjobs.agepartnership.co.uk/desk/tickets/5310366/messages

Created grid mixins so grid decs can have browser prefixes. Used https://css-tricks.com/css-grid-in-ie-css-grid-and-the-new-autoprefixer/#autoprefixer-has-new-super-powers as a reference of prefixes

The grid-cell mixin is inspired from https://css-tricks.com/browser-compatibility-css-grid-layouts-simple-sass-mixins/#the-sauce

Checks:
- Suitable mixins - have covered mixins that need browser prefixes which we'd use regularly
- Mixins are enough to get us going with some good layouts
- Malicious code

