### PR TITLE
Replace deprecated slash for division

### DIFF
--- a/base/_grid.scss
+++ b/base/_grid.scss
@@ -1,6 +1,6 @@
 // Grid
 // Example use: @include grid;
-@use "sass:list";
+@use 'sass:list';
 
 @mixin grid {
     display: -ms-grid;

--- a/base/_grid.scss
+++ b/base/_grid.scss
@@ -1,5 +1,7 @@
 // Grid
 // Example use: @include grid;
+@use "sass:list";
+
 @mixin grid {
     display: -ms-grid;
     display: grid;
@@ -32,9 +34,9 @@
 // Example use: @include grid-cell(2,2,1,1)
 @mixin grid-cell($col-start, $col-end, $row-start, $row-end) {
     -ms-grid-column: $col-start;
-    grid-column: #{$col-start}/#{$col-end};
+    grid-column: list.slash($col-start, $col-end);
     -ms-grid-column-span: $col-end - $col-start;
     -ms-grid-row: $row-start;
-    grid-row: #{$row-start}/#{$row-end};
+    grid-row: list.slash($row-start, $row-end);
     -ms-grid-row-span: $row-end - $row-start;
 }

--- a/base/_grid.scss
+++ b/base/_grid.scss
@@ -1,3 +1,5 @@
+@use 'sass:list';
+
 //Grid
 // Example use: @include grid(repeat(12, 1fr), auto, 32px);
 @mixin grid($columns: null, $row-height: null, $gap: null) {


### PR DESCRIPTION
Ticket: https://webjobs.agepartnership.co.uk/desk/tickets/5687300/messages

Changes:
- Use sass-migrator to change division slashes to multiplications or to use math.div()

Checks:
- Non-malicious
- Sense