### PR TITLE
Min-width fix for content when no paragraph

### DIFF
--- a/layouts/_content-wrap.scss
+++ b/layouts/_content-wrap.scss
@@ -2,6 +2,7 @@
     margin-left: auto;
     margin-right: auto;
     max-width: $content-wrap--max-width;
+    min-width: $content-wrap--min-width;
 
     @if $cancel-padding--left != true {
         padding-left: $content-wrap-padding--mobile;

--- a/variables/_layout.scss
+++ b/variables/_layout.scss
@@ -5,4 +5,3 @@ $content-wrap-padding--mobile: $base-unit * 3 !default;
 $content-wrap-padding--tablet: $base-unit * 6 !default;
 $content-wrap-padding--desktop: 75px !default;
 $content-wrap-padding--big-desktop: 100px !default;
-$content-wrap--min-width: 360px !default

--- a/variables/_layout.scss
+++ b/variables/_layout.scss
@@ -1,6 +1,8 @@
 $base-unit: 8px !default;
 $content-wrap--max-width: 1800px !default;
+$content-wrap--min-width: 360px !default;
 $content-wrap-padding--mobile: $base-unit * 3 !default;
 $content-wrap-padding--tablet: $base-unit * 6 !default;
 $content-wrap-padding--desktop: 75px !default;
 $content-wrap-padding--big-desktop: 100px !default;
+$content-wrap--min-width: 360px !default


### PR DESCRIPTION
Ticket: https://webjobs.agepartnership.co.uk/desk/tickets/6599885/messages
Task: https://webjobs.agepartnership.co.uk/app/tasks/15223912

Preview:

This will keep the text left aligned and prevent shrinking.

Checks:

- Preview the `hero-banner` component http://localhost:3000/components/detail/hero-banner--default
- In viewport size: 400w
- Add min-width to the `content-wrap` mixin which is used by `c-hero__content`. Display without paragraph content on mobile, content will now stay left aligned and not shrink which will look center.


Checks:

    Non-malicious
    Sense

