### PR TITLE
Change to u-hide hidden elements display specificity

### DIFF
--- a/utilities/_hidden-elements.scss
+++ b/utilities/_hidden-elements.scss
@@ -3,7 +3,7 @@
 @each $breakpoint in phone-only, tablet-portrait-up, tablet-portrait-only, tablet-landscape-up, tablet-landscape-only, desktop-up, desktop-only, big-desktop-up {
     .u-hide--#{$breakpoint} {
         @include breakpoint(#{$breakpoint}) {
-            display: none!important;
+            display: none !important;
         }
     }
 }

--- a/utilities/_hidden-elements.scss
+++ b/utilities/_hidden-elements.scss
@@ -1,9 +1,9 @@
 // The variables set to $breakpoint below directly correspond with what's set in base/_breakpoints.scss. Refer to that file for breakpoint info...
 
-@each $breakpoint in phone-only, tablet-portrait-up, tablet-portrait-only, tablet-landscape-up, tablet-landscape-only, desktop-up, desktop-only,  big-desktop-up {
+@each $breakpoint in phone-only, tablet-portrait-up, tablet-portrait-only, tablet-landscape-up, tablet-landscape-only, desktop-up, desktop-only, big-desktop-up {
     .u-hide--#{$breakpoint} {
         @include breakpoint(#{$breakpoint}) {
-            display: none;
+            display: none!important;
         }
     }
 }


### PR DESCRIPTION
Ticket: https://webjobs.agepartnership.co.uk/desk/tickets/6922840/tasks

Task: https://webjobs.agepartnership.co.uk/app/tasks/15413315

Required by changes on https://github.com/AgePartnership/oleg-component-library/pull/439

Thoughts on using the `!important` on items. I cannot see any issues with this as adding the class to an element would mean we would want either the current breakpoint or future breakpoints to be hidden.

- Current usage in component library: https://github.com/search?q=repo%3AAgePartnership%2Foleg-component-library%20u-hide--&type=code

- Usage in new.web: https://github.com/search?q=repo%3AAgePartnership%2Fnew.web.agepartnership.co.uk%20u-hide--&type=code

**Checks**

- Review
- Sanity
- Malice